### PR TITLE
Fix toggle logo in settings menu

### DIFF
--- a/settings/rocketstats.set
+++ b/settings/rocketstats.set
@@ -3,9 +3,9 @@ RocketStats Plugin
 8|
 0|Toggle menu|rs_toggle_menu
 7|
-9|  
+9|
 7|
-1|Hide the RocketStats logo|rs_toggle_logo
+1|Show the RocketStats logo|rs_toggle_logo
 8|
 9|Donate : https://www.paypal.me/rocketstats
 9|Discord : https://discord.gg/weBCBE4


### PR DESCRIPTION
Corrected the wording for the rs_toggle_logo boolean.

For some reason the two spaces after line 6 in the settings prevented it from rendering correctly. (My guess is some kind of markdown parsing behavior??).

Also, rs_toggle_logo, tied to https://github.com/Lyliya/RocketStats/blob/master/RocketStats/Managements/WindowManagement.cpp#L64, says "when true, show the logo", so the wording was backwards in the settings. (instead of doing `!rs_toggle_logo.getBoolValue()`, I just changed the wording in the settings)