### PR TITLE
Only call ShowPlugin() onLoad() if is_in_menu is true

### DIFF
--- a/RocketStats/RocketStats.cpp
+++ b/RocketStats/RocketStats.cpp
@@ -371,7 +371,8 @@ void RocketStats::onLoad()
 
                 gameWrapper->SetTimeout([&](GameWrapper* gameWrapper) {
                     UpdateUIScale("onLoad");
-                    ShowPlugin("onLoad");
+                    if (is_in_menu)
+                        ShowPlugin("onLoad");
                 }, 1.f);
                 return;
             }
@@ -380,7 +381,8 @@ void RocketStats::onLoad()
         onInit();
 
         UpdateUIScale("onLoad");
-        ShowPlugin("onLoad");
+        if (is_in_menu)
+            ShowPlugin("onLoad");
     });
 }
 


### PR DESCRIPTION
Currently when RocketStats is loaded (which generally occurs automatically when BakkesMod has been injected), the RS menu is toggled on by default. It is currently assumed that RS will always be loaded when the game starts and the menu is therefore displayed, however this is not always the case, such as when BakkesMod is injected while the player is in freeplay or training. The menu stays displayed until the player enters and exits the RocketLeague pause menu.

This PR adds an additional check for `is_in_menu` before toggling on the menu when the plugin loads so that it is not displayed while in freeplay (or otherwise hidden states).

![image](https://user-images.githubusercontent.com/10508906/179873305-b379cce7-32cf-4356-94bc-ac39ed344b9a.png)

_Admittedly, I do not have much experience at all with BakkesMod plugins and am uncertain how to go about setting up a development environment and build this project, let alone test it locally. I'm unsure if this patch even functions as desired. I made these changes based purely on a brief code assessment. If this is not the solution, I apologize and hope to at least bring attention to the issue at hand_