### PR TITLE
Added possibility to bind a key to reset stats.

### DIFF
--- a/RocketStats/RocketStats.cpp
+++ b/RocketStats/RocketStats.cpp
@@ -413,6 +413,11 @@ void RocketStats::onInit()
     cvarManager->registerNotifier("rs_toggle_menu", [this](std::vector<std::string> params) {
         ToggleSettings("rs_toggle_menu");
     }, GetLang(LANG_TOGGLE_MENU), PERMISSION_ALL);
+
+    cvarManager->registerNotifier("rs_reset_stats", [this](std::vector<std::string> params) {
+        ResetStats();
+    }, GetLang(LANG_RESET_STATS), PERMISSION_ALL);
+    
     cvarManager->registerNotifier("rs_menu_pos", [this](std::vector<std::string> params) {
         ToggleSettings("rs_toggle_menu", ToggleFlags_Hide);
 


### PR DESCRIPTION
Added possibility to bind a key to reset stats using the "rs_reset_stats" CVar.

<img width="1168" height="329" alt="image" src="https://github.com/user-attachments/assets/9dc9f920-1e82-445a-91e1-7d447262e940" />
